### PR TITLE
mps_cli.gradle-plugin: only use files modified in the current branch

### DIFF
--- a/demos/gradle-plugin-use/build.gradle
+++ b/demos/gradle-plugin-use/build.gradle
@@ -1,6 +1,6 @@
 
 plugins {
-    id 'com.mbeddr.mps_cli' version '0.4'
+    id 'com.mbeddr.mps_cli' version '0.5'
 }
 
 def directoryWithSources = ['C:\\work\\mps-cli\\mps_test_projects\\mps_cli_lanuse_file_per_root',

--- a/mps-cli-gradle-plugin/plugin/build.gradle
+++ b/mps-cli-gradle-plugin/plugin/build.gradle
@@ -19,7 +19,7 @@ plugins {
 
 // Project versions
 ext.major = '0'
-ext.minor = '5'
+ext.minor = '6'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/ConeOfInfluenceComputer.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/ConeOfInfluenceComputer.groovy
@@ -10,7 +10,7 @@ class ConeOfInfluenceComputer {
                                                                                 Map<SModuleBase, Set<SModuleBase>> module2AllUpstreamDependencies,
                                                                                 Map<SModuleBase, Set<SModuleBase>> module2AllDownstreamDependencies) {
 
-        List<File> differentModulesFiles = Filesystem2SSolutionBridge.computeModulesWhichAreDifferentFromBranch(gitRepoLocation, branchName)
+        List<File> differentModulesFiles = Filesystem2SSolutionBridge.computeModulesWhichAreModifiedInCurrentBranch(gitRepoLocation, branchName)
 
         List<String> differentModulesIds = differentModulesFiles.collect {
             SSolutionModuleBuilder builder = new SSolutionModuleBuilder()

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/Filesystem2SSolutionBridge.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/Filesystem2SSolutionBridge.groovy
@@ -4,9 +4,9 @@ import static groovy.io.FileType.FILES
 
 class Filesystem2SSolutionBridge {
 
-    static List<File> computeModulesWhichAreDifferentFromBranch(String gitRepoRootLocation, String branchName) {
+    static List<File> computeModulesWhichAreModifiedInCurrentBranch(String gitRepoRootLocation, String branchName) {
         def gitRepoLocation = new File(gitRepoRootLocation).canonicalPath
-        def differentFiles = GitFacade.computeFilesWhichAreDifferentFromBranch(gitRepoLocation, branchName)
+        def differentFiles = GitFacade.computeFilesWhichAreModifiedInCurrentBranch(gitRepoLocation, branchName)
 
         List<File> affectedModulesFiles = []
         def allAffectedFilesAreInsideSolutions = true

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/GitFacade.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/GitFacade.groovy
@@ -2,9 +2,9 @@ package org.mps_cli.cone_of_influence
 
 class GitFacade {
 
-    static List<String> computeFilesWhichAreDifferentFromBranch(gitRepoLocation, branchName) {
+    static List<String> computeFilesWhichAreModifiedInCurrentBranch(gitRepoLocation, branchName) {
         def sout = new StringBuilder(), serr = new StringBuilder()
-        def proc = "git diff --name-only $branchName".execute([], new File(gitRepoLocation))
+        def proc = "git diff --name-only --merge-base $branchName".execute([], new File(gitRepoLocation))
         proc.consumeProcessOutput(sout, serr)
         proc.waitForOrKill(5000)
 


### PR DESCRIPTION
Use [`git merge-base`](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt-emgitdiffemltoptionsgt--merge-baseltcommitgt--ltpathgt82308203) in gradle plugin. 
Now only changes done in the current branch since the separation from the reference branch. The changes done in the reference branch are ignored.