### PR TITLE
mps-cli-gradle-plugin: git diff syntax supported on < v2.30

### DIFF
--- a/mps-cli-gradle-plugin/plugin/build.gradle
+++ b/mps-cli-gradle-plugin/plugin/build.gradle
@@ -19,7 +19,7 @@ plugins {
 
 // Project versions
 ext.major = '0'
-ext.minor = '8'
+ext.minor = '9'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/GitFacade.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/GitFacade.groovy
@@ -4,7 +4,7 @@ class GitFacade {
 
     static List<String> computeFilesWhichAreModifiedInCurrentBranch(gitRepoLocation, branchName) {
         def sout = new StringBuilder(), serr = new StringBuilder()
-        def gitCommand = "git diff --name-only --merge-base $branchName --"
+        def gitCommand = "git diff --name-only $branchName... --"
         println ("Running git command '$gitCommand'")
         def proc = gitCommand.execute([], new File(gitRepoLocation))
         proc.consumeProcessOutput(sout, serr)


### PR DESCRIPTION
`git diff --merge-base $ref` syntax was added in git v2.30
The syntax supported in git v2.25 was `git diff $ref...` (Short for `git diff $ref...HEAD`)