### PR TITLE
mps-cli-gradle-plugin: Restored behaviour of git diff with local tree

### DIFF
--- a/mps-cli-gradle-plugin/plugin/build.gradle
+++ b/mps-cli-gradle-plugin/plugin/build.gradle
@@ -19,7 +19,7 @@ plugins {
 
 // Project versions
 ext.major = '0'
-ext.minor = '9'
+ext.minor = '10'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/GitFacade.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/GitFacade.groovy
@@ -2,25 +2,35 @@ package org.mps_cli.cone_of_influence
 
 class GitFacade {
 
-    static List<String> computeFilesWhichAreModifiedInCurrentBranch(gitRepoLocation, branchName) {
-        def sout = new StringBuilder(), serr = new StringBuilder()
-        def gitCommand = "git diff --name-only $branchName... --"
-        println ("Running git command '$gitCommand'")
-        def proc = gitCommand.execute([], new File(gitRepoLocation))
-        proc.consumeProcessOutput(sout, serr)
-        proc.waitForOrKill(5000)
+    static List<String> computeFilesWhichAreModifiedInCurrentBranch(String gitRepoLocation, String branchName) {
 
-        def differences = sout.toString().split('\n')
+        Closure<String> standardAndErrorOutputOfCommand = { String... command ->
+            def commandString = command.join(' ')
 
-        if (serr.toString()?.trim()) {
-            println ("Error while running git command '$gitCommand'")
-            println (">>>>>>>>>>>>")
-            print(serr.toString())
-            println ("<<<<<<<<<<<<")
+            def sout = new StringBuilder(), serr = new StringBuilder()
+            println("Running command '$commandString'")
+            def proc = command.execute([], new File(gitRepoLocation))
+            proc.consumeProcessOutput(sout, serr)
+            proc.waitForOrKill(5000)
+
+            def errorString = serr.toString()
+            if (errorString?.trim()) {
+                println ("Error running command '$commandString'")
+                println (">>>>>>>>>>>>")
+                print(errorString)
+                println ("<<<<<<<<<<<<")
+            }
+
+            sout.toString()
         }
 
+        def mergeBase = standardAndErrorOutputOfCommand('git', 'merge-base', branchName, 'HEAD').trim()
+
+        def differencesString = standardAndErrorOutputOfCommand('git', 'diff', '--name-only', mergeBase)
+        def differences = differencesString.split('\n')
+
         println("Differences:")
-        differences.each {println(it) }
+        differences.each { println(it) }
 
         differences
     }


### PR DESCRIPTION
Restored behaviour from plugin version 0.8: diff now done with the working tree instead of the current commit.
Git v2.25 is still supported

