### PR TITLE
mps-cli-gradle-plugin: Don't process deleted directories during path traverse

### DIFF
--- a/.github/workflows/mps_cli_build.yaml
+++ b/.github/workflows/mps_cli_build.yaml
@@ -37,6 +37,7 @@ jobs:
         build-root-directory: mps-cli-gradle-plugin
     - name: Publish
       uses: gradle/gradle-build-action@v2
+      if: github.event_name == 'push' && github.ref_name == 'main'
       with: 
         arguments: :plugin:publish -Pgpr.user=${{github.actor}} -Pgpr.token=${{ secrets.GITHUB_TOKEN }}
         wrapper-cache-enabled: true

--- a/mps-cli-gradle-plugin/plugin/build.gradle
+++ b/mps-cli-gradle-plugin/plugin/build.gradle
@@ -19,7 +19,7 @@ plugins {
 
 // Project versions
 ext.major = '0'
-ext.minor = '9'
+ext.minor = '10'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/Filesystem2SSolutionBridge.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/Filesystem2SSolutionBridge.groovy
@@ -18,8 +18,10 @@ class Filesystem2SSolutionBridge {
                 def myFile = new File(gitRepoLocation + File.separator + it).parentFile
                 def affectedModuleFound = false
                 while (myFile != null) {
-                    myFile.traverse(type: FILES, maxDepth: 0, nameFilter: filterSolutionFiles) {
-                        affectedModuleFound = true; affectedModulesFiles.add(it) }
+                    if (myFile.exists()) {
+                        myFile.traverse(type: FILES, maxDepth: 0, nameFilter: filterSolutionFiles) {
+                            affectedModuleFound = true; affectedModulesFiles.add(it) }
+                    }
                     if (affectedModuleFound) break
                     myFile = myFile.parentFile
                 }


### PR DESCRIPTION
Fixes traversing error when a whole directory is deleted

Also, modifies the pipeline to publish the plugin only from pushes to main