### PR TITLE
mps-cli-gradle-plugin: Replace java.io.File with java.nio.file.Path

### DIFF
--- a/mps-cli-gradle-plugin/plugin/build.gradle
+++ b/mps-cli-gradle-plugin/plugin/build.gradle
@@ -19,7 +19,7 @@ plugins {
 
 // Project versions
 ext.major = '0'
-ext.minor = '12'
+ext.minor = '13'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/mps-cli-gradle-plugin/plugin/src/functionalTest/groovy/org/mps_cli/gradle/plugin/SolutionsModelBuildingTest.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/functionalTest/groovy/org/mps_cli/gradle/plugin/SolutionsModelBuildingTest.groovy
@@ -15,8 +15,12 @@ task printSolutionsInfo {
         
         def library_second = repo.modules.find { it.name.equals("mps.cli.lanuse.library_second") ||
                                                 it.name.equals("mps.cli.lanuse.library_second.default_persistency") }
-        def normalizedSolutionPath = library_second.pathToModuleFile.replace("/", "\\\\")
-        println "solution $library_second.name is saved in directory $normalizedSolutionPath"
+        if (library_second.uriToModuleFileInJar != null) {
+            println "solution $library_second.name is saved in JAR with URI $library_second.uriToModuleFileInJar"
+        } else {
+            def normalizedSolutionPath = library_second.pathToModuleFile.replace("/", "\\\\")
+            println "solution $library_second.name is saved in directory $normalizedSolutionPath"
+        }
         
         def modules = repo.modules
         println "all modules: ${modules.collect { it.name }}"
@@ -29,8 +33,13 @@ task printSolutionsInfo {
         
         def modelWithImports = models.find { it.name.equals("mps.cli.lanuse.library_second.library_top") ||
                                              it.name.equals("mps.cli.lanuse.library_second.default_persistency.library_top") }
-        def normalizedModelPath = modelWithImports.pathToModelFile.replace("/", "\\\\")
-        println "path to model $modelWithImports.name is $normalizedModelPath"
+        if (modelWithImports.uriToModelFileInJar != null) {
+            println "URI to model $modelWithImports.name in JAR is $modelWithImports.uriToModelFileInJar"
+        } else {
+            def normalizedModelPath = modelWithImports.pathToModelFile.replace("/", "\\\\")
+            println "path to model $modelWithImports.name is $normalizedModelPath"
+        }
+        
         println "all models imported by 'mps.cli.lanuse.library_second.library_top': ${modelWithImports.imports.collect { it.resolve(repo).name }}"
         
         def allNodes = repo.allNodes()
@@ -68,8 +77,8 @@ task printSolutionsInfo {
                 it.contains("solutions\\mps.cli.lanuse.library_second\\mps.cli.lanuse.library_second.msd") ||
                 it.contains("solution mps.cli.lanuse.library_second.default_persistency is saved in directory") &&
                 it.contains("solutions\\mps.cli.lanuse.library_second.default_persistency\\mps.cli.lanuse.library_second.default_persistency.msd") ||
-                it.contains("solution mps.cli.lanuse.library_second is saved in directory") &&
-                it.contains("mps_cli_lanuse_binary\\mps_cli_lanuse_file_per_root.jar!\\mps.cli.lanuse.library_second\\mps.cli.lanuse.library_second.msd")
+                it.contains("solution mps.cli.lanuse.library_second is saved in JAR with URI jar:file:") &&
+                it.contains("mps_cli_lanuse_binary/mps_cli_lanuse_file_per_root.jar!/mps.cli.lanuse.library_second/mps.cli.lanuse.library_second.msd")
         }
 
         // check dependencies between solutions
@@ -86,8 +95,8 @@ task printSolutionsInfo {
                                             it.contains("solutions\\mps.cli.lanuse.library_second\\models\\mps.cli.lanuse.library_second.library_top\\.model") ||
                                             it.contains("path to model mps.cli.lanuse.library_second.default_persistency.library_top is") &&
                                             it.contains("solutions\\mps.cli.lanuse.library_second.default_persistency\\models\\mps.cli.lanuse.library_second.default_persistency.library_top.mps") ||
-                                            it.contains("path to model mps.cli.lanuse.library_second.library_top is") &&
-                                            it.contains("mps_cli_lanuse_binary\\mps_cli_lanuse_file_per_root.jar!\\mps.cli.lanuse.library_second\\models\\mps.cli.lanuse.library_second.library_top\\.model") }
+                                            it.contains("URI to model mps.cli.lanuse.library_second.library_top in JAR is jar:file:") &&
+                                            it.contains("mps_cli_lanuse_binary/mps_cli_lanuse_file_per_root.jar!/mps.cli.lanuse.library_second/models/mps.cli.lanuse.library_second.library_top/.model") }
 
         // check dependencies between models
         result.output.contains("all models imported by 'mps.cli.lanuse.library_second.library_top': [mps.cli.lanuse.library_top.authors_top]") ||

--- a/mps-cli-gradle-plugin/plugin/src/functionalTest/groovy/org/mps_cli/gradle/plugin/SolutionsModelBuildingTest.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/functionalTest/groovy/org/mps_cli/gradle/plugin/SolutionsModelBuildingTest.groovy
@@ -69,7 +69,7 @@ task printSolutionsInfo {
                 it.contains("solution mps.cli.lanuse.library_second.default_persistency is saved in directory") &&
                 it.contains("solutions\\mps.cli.lanuse.library_second.default_persistency\\mps.cli.lanuse.library_second.default_persistency.msd") ||
                 it.contains("solution mps.cli.lanuse.library_second is saved in directory") &&
-                it.contains("mps_cli_lanuse_binary\\mps_cli_lanuse_file_per_root.jar_tmp\\mps.cli.lanuse.library_second\\mps.cli.lanuse.library_second.msd")
+                it.contains("mps_cli_lanuse_binary\\mps_cli_lanuse_file_per_root.jar!\\mps.cli.lanuse.library_second\\mps.cli.lanuse.library_second.msd")
         }
 
         // check dependencies between solutions
@@ -87,7 +87,7 @@ task printSolutionsInfo {
                                             it.contains("path to model mps.cli.lanuse.library_second.default_persistency.library_top is") &&
                                             it.contains("solutions\\mps.cli.lanuse.library_second.default_persistency\\models\\mps.cli.lanuse.library_second.default_persistency.library_top.mps") ||
                                             it.contains("path to model mps.cli.lanuse.library_second.library_top is") &&
-                                            it.contains("mps_cli_lanuse_binary\\mps_cli_lanuse_file_per_root.jar_tmp\\mps.cli.lanuse.library_second\\models\\mps.cli.lanuse.library_second.library_top\\.model") }
+                                            it.contains("mps_cli_lanuse_binary\\mps_cli_lanuse_file_per_root.jar!\\mps.cli.lanuse.library_second\\models\\mps.cli.lanuse.library_second.library_top\\.model") }
 
         // check dependencies between models
         result.output.contains("all models imported by 'mps.cli.lanuse.library_second.library_top': [mps.cli.lanuse.library_top.authors_top]") ||

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/PathUtils.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/PathUtils.groovy
@@ -1,0 +1,20 @@
+package org.mps_cli
+
+import groovy.xml.XmlParser
+
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+
+class PathUtils {
+
+    static Node parseXml(Path pathToXmlFile) {
+        Files.newBufferedReader(pathToXmlFile).withCloseable { new XmlParser().parse(it) }
+    }
+
+    static String pathToString(Path path) {
+        path.getFileSystem() === FileSystems.default ?
+            path.toAbsolutePath().toString() :
+            path.toUri().toString()
+    }
+}

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/ConeOfInfluenceComputer.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/ConeOfInfluenceComputer.groovy
@@ -4,13 +4,15 @@ import org.mps_cli.model.SModuleBase
 import org.mps_cli.model.SSolutionModule
 import org.mps_cli.model.builder.SSolutionModuleBuilder
 
+import java.nio.file.Path
+
 class ConeOfInfluenceComputer {
 
     Tuple2<List<SModuleBase>, List<SModuleBase>> computeConeOfInfluence(String gitRepoLocation, List<String> allModifiedFiles,
                                                                                 Map<SModuleBase, Set<SModuleBase>> module2AllUpstreamDependencies,
                                                                                 Map<SModuleBase, Set<SModuleBase>> module2AllDownstreamDependencies) {
 
-        List<File> differentModulesFiles = Filesystem2SSolutionBridge.computeModulesWhichAreModifiedInCurrentBranch(gitRepoLocation, allModifiedFiles)
+        List<Path> differentModulesFiles = Filesystem2SSolutionBridge.computeModulesWhichAreModifiedInCurrentBranch(gitRepoLocation, allModifiedFiles)
 
         List<String> differentModulesIds = differentModulesFiles.collect {
             SSolutionModuleBuilder builder = new SSolutionModuleBuilder()

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/SModel.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/SModel.groovy
@@ -16,4 +16,23 @@ class SModel {
     Map<String, SNode> nodeId2Node() {
         allNodes.collectEntries {[it.id, it] }
     }
+
+    /**
+     * The file can be accessed with the ZIP file system (JVM 11+, Groovy code):
+     * <pre>
+     *     URI uri = sModel.uriToModelFileInJar();
+     *     if (uri != null) {
+     *          FileSystems.newFileSystem(uri, [:]).withCloseable { fileSystem ->
+     *              println Path.of(uri)
+     *          }
+     *     }
+     * </pre>
+     *
+     * @return URI to the model file inside the JAR file or null if the model file is not inside a JAR file.
+     */
+    URI getUriToModelFileInJar() {
+        if (pathToModelFile.startsWith("jar:file:")) {
+            URI.create(pathToModelFile)
+        } else null
+    }
 }

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/SModuleBase.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/SModuleBase.groovy
@@ -7,4 +7,23 @@ abstract class SModuleBase {
     List<SModuleRef> dependencies = []
 
     def abstract String name();
+
+    /**
+     * The file can be accessed with the ZIP file system (JVM 11+, Groovy code):
+     * <pre>
+     *     URI uri = sModule.uriToModuleFileInJar();
+     *     if (uri != null) {
+     *          FileSystems.newFileSystem(uri, [:]).withCloseable { fileSystem ->
+     *              println Path.of(uri)
+     *          }
+     *     }
+     * </pre>
+     *
+     * @return URI to the module file inside the JAR file or null if the module file is not inside a JAR file.
+     */
+    URI getUriToModuleFileInJar() {
+        if (pathToModuleFile.startsWith("jar:file:")) {
+            URI.create(pathToModuleFile)
+        } else null
+    }
 }

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/AbstractSModuleBuilder.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/AbstractSModuleBuilder.groovy
@@ -2,10 +2,16 @@ package org.mps_cli.model.builder
 
 import groovy.time.TimeCategory
 import groovy.time.TimeDuration
+import org.mps_cli.PathUtils
 import org.mps_cli.model.SModuleBase
 import org.mps_cli.model.SModuleRef
 import org.mps_cli.model.builder.default_persistency.SModelBuilderForDefaultPersistency
 import org.mps_cli.model.builder.file_per_root_persistency.SModelBuilderForFilePerRootPersistency
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import static java.util.stream.Collectors.toList
 
 abstract class AbstractSModuleBuilder {
 
@@ -13,46 +19,45 @@ abstract class AbstractSModuleBuilder {
 
     protected Node moduleXML;
 
-    def abstract File moduleFile(File pathToModuleDirectory);
+    abstract Path moduleFile(Path pathToModuleDirectory);
 
-    def build(String path) {
+    def build(Path pathToModuleDirectory) {
         Date start = new Date()
 
-        def pathToModuleDirectory = new File(path)
         def solutionFile = moduleFile(pathToModuleDirectory)
         SModuleBase sModuleBase = extractModuleCoreInfo(solutionFile)
-        sModuleBase.pathToModuleFile = solutionFile.absolutePath
+        sModuleBase.pathToModuleFile = PathUtils.pathToString(solutionFile)
 
-        for(Node dep : moduleXML.dependencies.dependency) {
+        for (Node dep : moduleXML.dependencies.dependency) {
             def moduleRefString = dep.text()
             def moduleIdRefString = moduleRefString.substring(0, moduleRefString.indexOf('('))
-            sModuleBase.dependencies.add(new SModuleRef(referencedModuleId : moduleIdRefString))
+            sModuleBase.dependencies.add(new SModuleRef(referencedModuleId: moduleIdRefString))
         }
 
         if (buildingStrategy != BuildingDepthEnum.MODULE_DEPENDENCIES_ONLY) {
-            def modelFiles = new File(pathToModuleDirectory, "models").listFiles()
-            modelFiles.findAll {it.isDirectory() }.each {
+            def modelFiles = Files.list(pathToModuleDirectory.resolve("models")).collect(toList())
+            modelFiles.findAll(Files.&isDirectory).each {
                 def modelBuilder = new SModelBuilderForFilePerRootPersistency(buildingStrategy: buildingStrategy)
-                def model = modelBuilder.build(it.absolutePath)
+                def model = modelBuilder.build(it.toAbsolutePath())
                 if (model != null) {
                     model.myModule = sModuleBase
                     sModuleBase.models.add(model)
                 }
             }
-            modelFiles.findAll {it.name.endsWith(".mps") }.each {
+            modelFiles.findAll { it.fileName.toString().endsWith(".mps") }.each {
                 def modelBuilder = new SModelBuilderForDefaultPersistency(buildingStrategy: buildingStrategy)
-                def model = modelBuilder.build(it.absolutePath)
+                def model = modelBuilder.build(it.toAbsolutePath())
                 sModuleBase.models.add(model)
                 model.myModule = sModuleBase
             }
         }
 
         Date stop = new Date()
-        TimeDuration td = TimeCategory.minus( stop, start )
-        println "${td} for handling ${path}"
+        TimeDuration td = TimeCategory.minus(stop, start)
+        println "${td} for handling ${pathToModuleDirectory}"
 
         sModuleBase
     }
 
-    def abstract SModuleBase extractModuleCoreInfo(File solutionFile);
+    abstract SModuleBase extractModuleCoreInfo(Path solutionFile);
 }

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/SLanguageModuleBuilder.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/SLanguageModuleBuilder.groovy
@@ -1,20 +1,22 @@
 package org.mps_cli.model.builder
 
-import groovy.xml.XmlParser
+import org.mps_cli.PathUtils
 import org.mps_cli.model.SLanguageModule
 import org.mps_cli.model.SModuleBase
-import org.mps_cli.model.SSolutionModule
+
+import java.nio.file.Files
+import java.nio.file.Path
 
 class SLanguageModuleBuilder extends AbstractSModuleBuilder {
 
     @Override
-    File moduleFile(File pathToModuleDirectory) {
-        pathToModuleDirectory.listFiles().find {it.name.endsWith(".mpl")}
+    Path moduleFile(Path pathToModuleDirectory) {
+        (Path) Files.list(pathToModuleDirectory).find { it.fileName.toString().endsWith(".mpl") }
     }
 
     @Override
-    SModuleBase extractModuleCoreInfo(File solutionFile) {
-        moduleXML = new XmlParser().parse(solutionFile)
+    SModuleBase extractModuleCoreInfo(Path solutionFile) {
+        moduleXML = PathUtils.parseXml(solutionFile)
         def sLanguageModule = new SLanguageModule()
         sLanguageModule.namespace = moduleXML.'@namespace'
         sLanguageModule.moduleId = moduleXML.'@uuid'

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/SSolutionModuleBuilder.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/SSolutionModuleBuilder.groovy
@@ -1,20 +1,22 @@
 package org.mps_cli.model.builder
 
-
-import groovy.xml.XmlParser
-import org.mps_cli.model.SModuleBase
+import org.mps_cli.PathUtils
 import org.mps_cli.model.SSolutionModule
+
+import java.nio.file.Files
+import java.nio.file.Path
 
 class SSolutionModuleBuilder extends AbstractSModuleBuilder {
 
     @Override
-    File moduleFile(File pathToModuleDirectory) {
-        pathToModuleDirectory.listFiles().find {it.name.endsWith(".msd")}
+    Path moduleFile(Path pathToModuleDirectory) {
+        (Path) Files.list(pathToModuleDirectory).find { it.fileName.toString().endsWith(".msd") }
     }
 
     @Override
-    SSolutionModule extractModuleCoreInfo(File solutionFile) {
-        moduleXML = new XmlParser().parse(solutionFile)
+    SSolutionModule extractModuleCoreInfo(Path solutionFile) {
+
+        moduleXML = PathUtils.parseXml(solutionFile)
         def sSolution = new SSolutionModule()
         sSolution.name = moduleXML.'@name'
         sSolution.moduleId = moduleXML.'@uuid'

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/default_persistency/SModelBuilderForDefaultPersistency.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/default_persistency/SModelBuilderForDefaultPersistency.groovy
@@ -2,23 +2,21 @@ package org.mps_cli.model.builder.default_persistency
 
 import groovy.time.TimeCategory
 import groovy.time.TimeDuration
-import groovy.xml.XmlParser
-import org.mps_cli.model.SModel
+import org.mps_cli.PathUtils
 import org.mps_cli.model.builder.AbstractModelBuilder
 import org.mps_cli.model.builder.BuildingDepthEnum
-import org.mps_cli.model.builder.file_per_root_persistency.RootNodeFromMpsrBuilder
 
-import static groovy.io.FileType.FILES
+import java.nio.file.Path
 
 class SModelBuilderForDefaultPersistency extends AbstractModelBuilder {
 
-    def build(String pathToMsdFile) {
+    def build(Path pathToMsdFile) {
         Date start = new Date()
 
-        def modelXML = new XmlParser().parse(pathToMsdFile)
+        def modelXML = PathUtils.parseXml(pathToMsdFile)
         def sModel = buildModelFromXML(modelXML)
         sModel.isFilePerRootPersistency = false
-        sModel.pathToModelFile = pathToMsdFile
+        sModel.pathToModelFile = PathUtils.pathToString(pathToMsdFile)
 
         if (buildingStrategy != BuildingDepthEnum.MODEL_DEPENDENCIES_ONLY) {
             def builder = new RootNodeFromMsdBuilder()
@@ -32,6 +30,4 @@ class SModelBuilderForDefaultPersistency extends AbstractModelBuilder {
 
         sModel
     }
-
-
 }

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/file_per_root_persistency/RootNodeFromMpsrBuilder.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/file_per_root_persistency/RootNodeFromMpsrBuilder.groovy
@@ -1,14 +1,15 @@
 package org.mps_cli.model.builder.file_per_root_persistency
 
-import groovy.xml.XmlParser
+import org.mps_cli.PathUtils
 import org.mps_cli.model.SModel
 import org.mps_cli.model.builder.AbstractRootNodeBuilder
 
+import java.nio.file.Path
+
 class RootNodeFromMpsrBuilder extends AbstractRootNodeBuilder {
 
-
-    def build(File mpsrFile, SModel sModel) {
-        def model = new XmlParser().parse(mpsrFile)
+    def build(Path mpsrFile, SModel sModel) {
+        def model = PathUtils.parseXml(mpsrFile)
         collectRegistryInfo(model)
         Node xmlNode = model.node.get(0)
         def res = collectNodes(xmlNode, null, sModel)


### PR DESCRIPTION
Changes:

* Replaced in most places usage of java.io.File with `java.nio.file.Path`. This should make it work with Unicode model paths on some systems/locales
* Replaced unpacking a JAR of a binary module with traversing file structure directly inside a JAR using `java.nio.file.FileSystem`. This simplifies the code a bit.
* `SModuleBase.pathToModuleFile` and `SModel.pathToModelFile` for binary (JAR) modules are now set to URIs of files inside the JAR, instead of a wrong path to a deleted temporary directory. The module/model files in binary modules can be accessed programatically through the URI (requires Java 11). 
* Added methods `SModuleBase.getUriToModuleFileInJar()` and `SModel.getUriToModelFileInJar()` to distinguish when the `pathTo...File` contains a path or a URI:

```groovy
def uri = module.uriToModuleFileInJar
if (uri != null) {
  FileSystems.newFileSystem(uri, [:]).withCloseable { fs ->
    println Path.of(uri)
  }
} else {
  println Path.of(module.pathToModuleFile)
}
```