### PR TITLE
mps-cli-gradle-plugin: Empty list of models when no models dir

### DIFF
--- a/mps-cli-gradle-plugin/plugin/build.gradle
+++ b/mps-cli-gradle-plugin/plugin/build.gradle
@@ -19,7 +19,7 @@ plugins {
 
 // Project versions
 ext.major = '0'
-ext.minor = '13'
+ext.minor = '14'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/GitFacade.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/GitFacade.groovy
@@ -14,7 +14,7 @@ class GitFacade {
             println("Running command '$commandString'")
             def proc = command.execute([], absoluteGitRepoLocation)
             proc.consumeProcessOutput(sout, serr)
-            proc.waitForOrKill(5000)
+            proc.waitForOrKill(60000)
 
             def errorString = serr.toString()
             if (errorString?.trim()) {

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/GitFacade.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/cone_of_influence/GitFacade.groovy
@@ -16,6 +16,12 @@ class GitFacade {
             proc.consumeProcessOutput(sout, serr)
             proc.waitForOrKill(60000)
 
+            if (proc.exitValue() != 0) {
+                throw new RuntimeException(
+                        """Error running command '$commandString' - 
+                            process failed with exit code ${proc.exitValue()}""".stripIndent())
+            }
+
             def errorString = serr.toString()
             if (errorString?.trim()) {
                 throw new RuntimeException(

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/AbstractSModuleBuilder.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/AbstractSModuleBuilder.groovy
@@ -35,7 +35,8 @@ abstract class AbstractSModuleBuilder {
         }
 
         if (buildingStrategy != BuildingDepthEnum.MODULE_DEPENDENCIES_ONLY) {
-            def modelFiles = Files.list(pathToModuleDirectory.resolve("models")).collect(toList())
+            def modelsDir = pathToModuleDirectory.resolve("models")
+            def modelFiles = Files.exists(modelsDir) ? Files.list(modelsDir).collect(toList()) : []
             modelFiles.findAll(Files.&isDirectory).each {
                 def modelBuilder = new SModelBuilderForFilePerRootPersistency(buildingStrategy: buildingStrategy)
                 def model = modelBuilder.build(it.toAbsolutePath())


### PR DESCRIPTION
Fixed `buildModel` task failing when some solution didn't have `models` directory. 