### PR TITLE
meta/Moved log messages when building dependencies to info level

### DIFF
--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/AbstractSModuleBuilder.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/AbstractSModuleBuilder.groovy
@@ -7,6 +7,7 @@ import org.mps_cli.model.SModuleBase
 import org.mps_cli.model.SModuleRef
 import org.mps_cli.model.builder.default_persistency.SModelBuilderForDefaultPersistency
 import org.mps_cli.model.builder.file_per_root_persistency.SModelBuilderForFilePerRootPersistency
+import org.slf4j.LoggerFactory
 
 import java.nio.file.Files
 import java.nio.file.Path
@@ -14,6 +15,8 @@ import java.nio.file.Path
 import static java.util.stream.Collectors.toList
 
 abstract class AbstractSModuleBuilder {
+
+    private def timingLogger = LoggerFactory.getLogger('repository-builder-timing')
 
     BuildingDepthEnum buildingStrategy = BuildingDepthEnum.COMPLETE_MODEL;
 
@@ -55,7 +58,7 @@ abstract class AbstractSModuleBuilder {
 
         Date stop = new Date()
         TimeDuration td = TimeCategory.minus(stop, start)
-        println "${td} for handling ${pathToModuleDirectory}"
+        timingLogger.info "{} for handling {}", td, pathToModuleDirectory
 
         sModuleBase
     }

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/default_persistency/SModelBuilderForDefaultPersistency.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/default_persistency/SModelBuilderForDefaultPersistency.groovy
@@ -5,10 +5,13 @@ import groovy.time.TimeDuration
 import org.mps_cli.PathUtils
 import org.mps_cli.model.builder.AbstractModelBuilder
 import org.mps_cli.model.builder.BuildingDepthEnum
+import org.slf4j.LoggerFactory
 
 import java.nio.file.Path
 
 class SModelBuilderForDefaultPersistency extends AbstractModelBuilder {
+
+    private def timingLogger = LoggerFactory.getLogger('repository-builder-timing')
 
     def build(Path pathToMsdFile) {
         Date start = new Date()
@@ -26,7 +29,7 @@ class SModelBuilderForDefaultPersistency extends AbstractModelBuilder {
 
         Date stop = new Date()
         TimeDuration td = TimeCategory.minus( stop, start )
-        println "${td} for handling ${pathToMsdFile}"
+        timingLogger.info "{} for handling {}", td, pathToMsdFile
 
         sModel
     }

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/file_per_root_persistency/SModelBuilderForFilePerRootPersistency.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/model/builder/file_per_root_persistency/SModelBuilderForFilePerRootPersistency.groovy
@@ -5,6 +5,7 @@ import groovy.time.TimeDuration
 import org.mps_cli.PathUtils
 import org.mps_cli.model.builder.AbstractModelBuilder
 import org.mps_cli.model.builder.BuildingDepthEnum
+import org.slf4j.LoggerFactory
 
 import java.nio.file.Files
 import java.nio.file.Path
@@ -12,6 +13,8 @@ import java.nio.file.Path
 import static groovy.io.FileType.FILES
 
 class SModelBuilderForFilePerRootPersistency extends AbstractModelBuilder {
+
+    private def timingLogger = LoggerFactory.getLogger('repository-builder-timing')
 
     def build(Path path) {
         Date start = new Date()
@@ -35,7 +38,7 @@ class SModelBuilderForFilePerRootPersistency extends AbstractModelBuilder {
 
         Date stop = new Date()
         TimeDuration td = TimeCategory.minus( stop, start )
-        println "${td} for handling ${path}"
+        timingLogger.info "{} for handling {}", td, path
 
         sModel
     }


### PR DESCRIPTION
Reduces message spam when calling `buildModelDependencies`/`buildModuleDependencies` tasks without `--info` flag