### PR TITLE
Feature/mps cli python file filter for file per root persistency

### DIFF
--- a/mps-cli-py/src/mpscli/model/SModel.py
+++ b/mps-cli-py/src/mpscli/model/SModel.py
@@ -8,6 +8,7 @@ class SModel:
         self.root_nodes = []
         self.path_to_model_file = ""
         self.is_do_not_generate = is_do_not_generate
+        self.uuid_2_nodes = {}
 
     def get_nodes(self):
         res = []
@@ -17,7 +18,7 @@ class SModel:
         return res
 
     def get_node_by_uuid(self, uuid):
-        for n in self.get_nodes():
-            if n.uuid == uuid:
-                return n
-        return None
+        if len(self.uuid_2_nodes) == 0:
+            for n in self.get_nodes():
+                self.uuid_2_nodes[n.uuid] = n
+        return self.uuid_2_nodes[uuid]

--- a/mps-cli-py/src/mpscli/model/SNode.py
+++ b/mps-cli-py/src/mpscli/model/SNode.py
@@ -10,7 +10,7 @@ class SNode:
         self.children = []
 
     def get_property(self, name):
-        return self.properties[name]
+        return self.properties.get(name)
 
     def get_reference(self, name):
         return self.references[name]

--- a/mps-cli-py/src/mpscli/model/SRepository.py
+++ b/mps-cli-py/src/mpscli/model/SRepository.py
@@ -4,6 +4,7 @@ class SRepository:
     def __init__(self):
         self.solutions = []
         self.languages = []
+        self.model_2_uuid = {}
 
     def find_solution_by_name(self, name):
         for sol in self.solutions:
@@ -52,8 +53,8 @@ class SRepository:
         return res
 
     def get_model_by_uuid(self, uuid):
-        for sol in self.solutions:
-            for m in sol.models:
-                if m.uuid == uuid:
-                    return m
-        return None
+        if len(self.model_2_uuid) == 0:
+            for sol in self.solutions:
+                for m in sol.models:
+                    self.model_2_uuid[m.uuid] = m
+        return self.model_2_uuid.get(uuid)

--- a/mps-cli-py/src/mpscli/model/builder/SModelBuilderFilePerRootPersistency.py
+++ b/mps-cli-py/src/mpscli/model/builder/SModelBuilderFilePerRootPersistency.py
@@ -1,9 +1,21 @@
-
 from mpscli.model.builder.SModelBuilderBase import SModelBuilderBase
 import xml.etree.ElementTree as ET
 
 
+class MpsrFileFiler:
+
+    def is_mpsr_file_needed(self, file):
+        return True
+
+
 class SModelBuilderFilePerRootPersistency(SModelBuilderBase):
+
+    def __init__(self, mpsr_file_filter=None):
+        if mpsr_file_filter is None:
+            self.mpsr_file_filter = MpsrFileFiler()
+        else:
+            self.mpsr_file_filter = mpsr_file_filter
+        super().__init__()
 
     def build(self, path):
         model_file = path / '.model'
@@ -13,7 +25,7 @@ class SModelBuilderFilePerRootPersistency(SModelBuilderBase):
         model.path_to_model_file = model_file
 
         for file in path.iterdir():
-            if file.suffix == '.mpsr':
+            if file.suffix == '.mpsr' and self.mpsr_file_filter.is_mpsr_file_needed(file):
                 root_node = self.extract_root_node(model, file)
                 model.root_nodes.append(root_node)
 
@@ -25,6 +37,3 @@ class SModelBuilderFilePerRootPersistency(SModelBuilderBase):
         self.extract_imports_and_registry(model_xml_node)
         root_node = model_xml_node.find("node")
         return self.extract_node(model, root_node)
-
-
-

--- a/mps-cli-py/src/mpscli/model/builder/SSolutionBuilder.py
+++ b/mps-cli-py/src/mpscli/model/builder/SSolutionBuilder.py
@@ -7,7 +7,7 @@ from mpscli.model.builder.SModelBuilderFilePerRootPersistency import SModelBuild
 
 class SSolutionBuilder:
 
-    def build_solution(self, path_to_msd_file):
+    def build_solution(self, path_to_msd_file, file_filter=None):
         solution = self.extract_solution_core_info(path_to_msd_file)
         path_to_solution_dir = path_to_msd_file.parent
         solution.path_to_solution_file = path_to_msd_file
@@ -19,7 +19,7 @@ class SSolutionBuilder:
 
         for path_to_model in path_to_models_dir.iterdir():
             if path_to_model.is_dir():
-                builder = SModelBuilderFilePerRootPersistency()
+                builder = SModelBuilderFilePerRootPersistency(file_filter)
             else:
                 builder = SModelBuilderDefaultPersistency()
             model = builder.build(path_to_model)

--- a/mps-cli-py/src/mpscli/model/builder/SSolutionsRepositoryBuilder.py
+++ b/mps-cli-py/src/mpscli/model/builder/SSolutionsRepositoryBuilder.py
@@ -14,7 +14,7 @@ class SSolutionsRepositoryBuilder:
     def __init__(self):
         self.repo = SRepository()
 
-    def build(self, path):
+    def build(self, path, file_filter=None):
         if not os.path.exists(path):
             print("ERROR: path", path, "does not exist!")
             sys.exit(1)
@@ -24,29 +24,29 @@ class SSolutionsRepositoryBuilder:
 
         print("building model from path:", path)
         start = timer()
-        self.collect_solutions_from_sources(path)
-        self.collect_solutions_from_jars(path)
+        self.collect_solutions_from_sources(path, file_filter)
+        self.collect_solutions_from_jars(path, file_filter)
         self.repo.languages = list(SLanguageBuilder.languages.values())
         stop = timer()
         duration = (stop - start)
         print('duration is: ' + str(duration) + ' seconds')
         return self.repo
 
-    def collect_solutions_from_sources(self, path):
+    def collect_solutions_from_sources(self, path, file_filter=None):
         for pth in Path(path).rglob('*.msd'):
             solutionBuilder = SSolutionBuilder()
-            solution = solutionBuilder.build_solution(pth)
+            solution = solutionBuilder.build_solution(pth, file_filter)
             if solution is not None:
                 self.repo.solutions.append(solution)
 
-    def collect_solutions_from_jars(self, path):
+    def collect_solutions_from_jars(self, path, file_filter=None):
         for jar_path in Path(path).rglob('*.jar'):
             directory_where_to_extract = jar_path.parent / jar_path.name.replace(".", "_")
             directory_where_to_extract.mkdir(parents=True, exist_ok=True)
             with zipfile.ZipFile(jar_path) as jar:
                 jar.extractall(directory_where_to_extract)
                 print("path = ", directory_where_to_extract)
-                self.collect_solutions_from_sources(directory_where_to_extract)
+                self.collect_solutions_from_sources(directory_where_to_extract, file_filter)
             try:
                 shutil.rmtree(directory_where_to_extract)
             except OSError as e:


### PR DESCRIPTION
mps cli python: add a new file filter for parsing models with file per root persistency that allows the caller to decide which mpsr files should be parsed and which should be ignored