### PR TITLE
Fix deprecated groovy space assignment

### DIFF
--- a/.github/workflows/mps_cli_build.yaml
+++ b/.github/workflows/mps_cli_build.yaml
@@ -1,6 +1,6 @@
 name: MPS-CLI_CI
 
-on: 
+on:
   push:
     branches:
       - 'main'
@@ -28,10 +28,10 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 11  
+        java-version: 11
     - name: Build MPS-CLI and Test
       uses: gradle/gradle-build-action@v2
-      with: 
+      with:
         arguments: :plugin:functionalTest --debug
         wrapper-cache-enabled: true
         dependencies-cache-enabled: true
@@ -39,7 +39,7 @@ jobs:
         dependencies-cache-exact: true
         configuration-cache-enabled: true
         build-root-directory: mps-cli-gradle-plugin
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: gradle-test-report
@@ -47,7 +47,7 @@ jobs:
     - name: Publish
       uses: gradle/gradle-build-action@v2
       if: github.event_name == 'push' && github.ref_name == 'main'
-      with: 
+      with:
         arguments: :plugin:publish -Pgpr.user=${{github.actor}} -Pgpr.token=${{ secrets.GITHUB_TOKEN }}
         wrapper-cache-enabled: true
         dependencies-cache-enabled: true

--- a/mps-cli-gradle-plugin/plugin/build.gradle
+++ b/mps-cli-gradle-plugin/plugin/build.gradle
@@ -20,7 +20,7 @@ plugins {
 
 // Project versions
 ext.major = '0'
-ext.minor = '17'
+ext.minor = '18'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -97,22 +97,22 @@ application {
 publishing {
     repositories {
         maven {
-			name = "GitHubPackages"
-			url = uri("https://maven.pkg.github.com/mbeddr/mps-cli")
-			if(project.hasProperty("gpr.token")) {
-				credentials {
-					username = project.findProperty("gpr.user")
-					password = project.findProperty("gpr.token")
-				}
-			}
-		}
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/mbeddr/mps-cli")
+            if (project.hasProperty("gpr.token")) {
+                credentials {
+                    username = project.findProperty("gpr.user")
+                    password = project.findProperty("gpr.token")
+                }
+            }
+        }
     }
 
     publications {
         maven(MavenPublication) {
             groupId = 'com.mbeddr.mps_cli'
             artifactId = 'gradle.plugin'
-            
+
             from components.java
         }
     }

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/gradle/plugin/ConeOfInfluenceComputerTask.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/gradle/plugin/ConeOfInfluenceComputerTask.groovy
@@ -39,8 +39,8 @@ class ConeOfInfluenceComputerTask extends DefaultTask {
     List<SModuleBase> affectedSolutionsAndUpstreamDependencies
 
     ConeOfInfluenceComputerTask() {
-        group "MPS-CLI"
-        description "computes the solutions potentially affected (and their dependencies) of the changes from current branch compared to 'referenceBranchName' from the 'gitRootRepoLocation'"
+        group = "MPS-CLI"
+        description = "computes the solutions potentially affected (and their dependencies) of the changes from current branch compared to 'referenceBranchName' from the 'gitRootRepoLocation'"
     }
 
     @TaskAction

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/gradle/plugin/ModelBuilderTask.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/gradle/plugin/ModelBuilderTask.groovy
@@ -16,8 +16,8 @@ class ModelBuilderTask extends DefaultTask {
     SRepository repository;
 
     ModelBuilderTask() {
-        group("MPS-CLI")
-        description("build the object model based on MPS files from 'sourceDir'")
+        group = "MPS-CLI"
+        description = "build the object model based on MPS files from 'sourceDir'"
     }
 
     @TaskAction

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/gradle/plugin/ModelDependenciesBuilderTask.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/gradle/plugin/ModelDependenciesBuilderTask.groovy
@@ -21,8 +21,8 @@ class ModelDependenciesBuilderTask extends DefaultTask {
     Map<SModel, Set<SModel>> model2AllDownstreamDependencies = [:];
 
     ModelDependenciesBuilderTask() {
-        group("MPS-CLI")
-        description("build the upstream/downstream dependencies for all models based on MPS files from 'sourceDir' list")
+        group = "MPS-CLI"
+        description = "build the upstream/downstream dependencies for all models based on MPS files from 'sourceDir' list"
     }
 
     @TaskAction

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/gradle/plugin/ModuleDependenciesBuilderTask.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/gradle/plugin/ModuleDependenciesBuilderTask.groovy
@@ -21,8 +21,8 @@ class ModuleDependenciesBuilderTask extends DefaultTask {
     Map<SModuleBase, Set<SModuleBase>> module2AllDownstreamDependencies = [:];
 
     ModuleDependenciesBuilderTask() {
-        group("MPS-CLI")
-        description("build the upstream/downstream dependencies for all modules based on MPS files from 'sourceDir' list")
+        group = "MPS-CLI"
+        description = "build the upstream/downstream dependencies for all modules based on MPS files from 'sourceDir' list"
     }
 
     @TaskAction

--- a/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/gradle/plugin/PrintLanguageInfoTask.groovy
+++ b/mps-cli-gradle-plugin/plugin/src/main/groovy/org/mps_cli/gradle/plugin/PrintLanguageInfoTask.groovy
@@ -12,8 +12,8 @@ class PrintLanguageInfoTask extends DefaultTask {
     String destinationDir;
 
     PrintLanguageInfoTask() {
-        group "MPS-CLI"
-        description "print information about the DSLs"
+        group = "MPS-CLI"
+        description = "print information about the DSLs"
         dependsOn "buildModel"
     }
 


### PR DESCRIPTION
For more information check the Gradle migration docs https://docs.gradle.org/current/userguide/upgrading_version_8.html#groovy_space_assignment_syntax

This avoids warnings in the build of projects using this as an underlying plugin.

```
Space-assignment syntax in Groovy DSL has been deprecated.
```