### PR TITLE
mps-cli-py: minor update for readme and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ gradle.properties
 **/workspace.xml
 **/misc.xml
 **/__pycache__/
+**/.DS_Store

--- a/mps-cli-py/Readme.md
+++ b/mps-cli-py/Readme.md
@@ -4,7 +4,7 @@ This project provides a Python library which parses MPS files and builds the obj
 
 ### Features
 The following features are available:
-- load MPS files (*.mpsr, *.mps, *.jar) and expose their content as Python object model 
+- load MPS files (*.mpsr, *.mps, *.mpb, *.jar) and expose their content as Python object model 
   - solutions, models, root nodes, nodes, children, references, properties
 - extract the meta-information and expose it as Python object model
   - list of languages, their concepts with information about properties, references, children
@@ -18,6 +18,7 @@ The core of the Python object model is given by the following classes:
 ### Limitations
 The library has currently the following limitations:
 - the recovered language information reflects only the used language in the loaded solutions
+  - if "mps/plugins" directory is considered the language information is loaded as an object model
 
 ### Run tests
 

--- a/mps-cli-py/pyproject.toml
+++ b/mps-cli-py/pyproject.toml
@@ -4,10 +4,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mps-cli"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
   { name="Daniel Ratiu", email="ratiud@googlemail.com" },
   { name="Prithvi Venkat", email="prithvi.rvce@gmail.com" },
+  { name="Michael Langhammer", email="mich.langhammer@googlemail.com" },
 ]
 description = "MPS Command Line Interface (MPS-CLI) is a library to parse MPS files and build the model as Python objects."
 readme = "README.md"


### PR DESCRIPTION
general changes:
- add DS_Store files to gitignore to avoid huge amount of changes on macOS

changes in mps-cli-py:
- Adapt the readme to clarify that mpb files can now be parsed 
- bump version to 0.6

