### PR TITLE
mps-cli-py: extended SModel class to include imported models

### DIFF
--- a/mps-cli-py/src/mpscli/model/SModel.py
+++ b/mps-cli-py/src/mpscli/model/SModel.py
@@ -2,9 +2,10 @@
 
 class SModel:
 
-    def __init__(self, name, uuid, is_do_not_generate):
+    def __init__(self, name, uuid, is_do_not_generate, imported_models=None):
         self.name = name
         self.uuid = uuid
+        self.imported_models = {} if imported_models is None else imported_models
         self.root_nodes = []
         self.path_to_model_file = ""
         self.is_do_not_generate = is_do_not_generate

--- a/mps-cli-py/src/mpscli/model/builder/SModelBuilderBase.py
+++ b/mps-cli-py/src/mpscli/model/builder/SModelBuilderBase.py
@@ -51,20 +51,32 @@ class SModelBuilderBase:
             for attribute in model_xml_node.findall("attribute")
         )
 
+    @staticmethod
+    def extract_imported_models(model_xml_node):
+        imported_models = {}
+        imports_xml_node = model_xml_node.find("imports")
+        if imports_xml_node is None:
+            return imported_models
+
+        for import_xml_node in imports_xml_node.findall("import"):
+            import_index = import_xml_node.get("index")
+            imported_model_ref = import_xml_node.get("ref")
+            imported_model_uuid = imported_model_ref[0 : imported_model_ref.find("(")]
+            imported_models[import_index] = imported_model_uuid
+
+        return imported_models
+
     def extract_model_core_info(self, model_xml_node):
         model_ref = model_xml_node.get("ref")
         model_name = model_ref[model_ref.find("(") + 1 : len(model_ref) - 1]
         model_uuid = model_ref[0 : model_ref.find("(")]
         model_is_do_not_generate = self.is_model_generatable(model_xml_node)
-        model = SModel(model_name, model_uuid, model_is_do_not_generate)
+        model_imported_models = self.extract_imported_models(model_xml_node)
+        model = SModel(model_name, model_uuid, model_is_do_not_generate, model_imported_models)
         return model
 
     def extract_imports_and_registry(self, model_xml_node):
-        imports_xml_node = model_xml_node.find("imports")
-        for import_xml_node in imports_xml_node.findall("import"):
-            import_index = import_xml_node.get("index")
-            imported_model_ref = import_xml_node.get("ref")
-            imported_model_uuid = imported_model_ref[0: imported_model_ref.find("(")]
+        for import_index, imported_model_uuid in self.extract_imported_models(model_xml_node).items():
             self.index_2_imported_model_uuid[import_index] = imported_model_uuid
         registry_xml_node = model_xml_node.find("registry")
         for language_xml_node in registry_xml_node.findall("language"):

--- a/mps-cli-py/src/mpscli/model/builder/SModelBuilderBase.py
+++ b/mps-cli-py/src/mpscli/model/builder/SModelBuilderBase.py
@@ -52,7 +52,7 @@ class SModelBuilderBase:
         )
 
     @staticmethod
-    def extract_imported_models(model_xml_node):
+    def extract_imported_models(self, model_xml_node):
         imported_models = {}
         imports_xml_node = model_xml_node.find("imports")
         if imports_xml_node is None:
@@ -63,6 +63,7 @@ class SModelBuilderBase:
             imported_model_ref = import_xml_node.get("ref")
             imported_model_uuid = imported_model_ref[0 : imported_model_ref.find("(")]
             imported_models[import_index] = imported_model_uuid
+            self.index_2_imported_model_uuid[import_index] = imported_model_uuid        
 
         return imported_models
 
@@ -71,13 +72,11 @@ class SModelBuilderBase:
         model_name = model_ref[model_ref.find("(") + 1 : len(model_ref) - 1]
         model_uuid = model_ref[0 : model_ref.find("(")]
         model_is_do_not_generate = self.is_model_generatable(model_xml_node)
-        model_imported_models = self.extract_imported_models(model_xml_node)
+        model_imported_models = self.extract_imported_models(self, model_xml_node)
         model = SModel(model_name, model_uuid, model_is_do_not_generate, model_imported_models)
         return model
 
-    def extract_imports_and_registry(self, model_xml_node):
-        for import_index, imported_model_uuid in self.extract_imported_models(model_xml_node).items():
-            self.index_2_imported_model_uuid[import_index] = imported_model_uuid
+    def extract_registry(self, model_xml_node):
         registry_xml_node = model_xml_node.find("registry")
         for language_xml_node in registry_xml_node.findall("language"):
             language_id = language_xml_node.get("id")

--- a/mps-cli-py/src/mpscli/model/builder/SModelBuilderBinaryPersistency.py
+++ b/mps-cli-py/src/mpscli/model/builder/SModelBuilderBinaryPersistency.py
@@ -93,12 +93,12 @@ class SModelBuilderBinaryPersistency(SModelBuilderBase):
 
         uuid_str = model_uuid or "r:unknown"
         name_str = model_name or "unknown.model"
-        model = SModel(name_str, uuid_str, False)
 
         # Import index 0 is always the current model's own uuid..
         # Java: SModel.importedModels() lists imports starting from index 1 and index 0 is implicitly
         # the model itself used when resolving REF_THIS_MODEL
         self.index_2_imported_model_uuid["0"] = uuid_str
+        model = SModel(name_str, uuid_str, False)
 
         # 2. registry - builds concept/property/reference/child index maps
         load_registry(reader, self)
@@ -115,6 +115,12 @@ class SModelBuilderBinaryPersistency(SModelBuilderBase):
             # is usually intact even when an unusual import reference sub-kind is encountered
             advance_until_after(reader, MODEL_START)
             return model
+
+        model.imported_models = {
+            index: imported_model_uuid
+            for index, imported_model_uuid in self.index_2_imported_model_uuid.items()
+            if index != "0"
+        }
 
         # 4. MODEL_START
         token = reader.read_u32()

--- a/mps-cli-py/src/mpscli/model/builder/SModelBuilderDefaultPersistency.py
+++ b/mps-cli-py/src/mpscli/model/builder/SModelBuilderDefaultPersistency.py
@@ -10,7 +10,7 @@ class SModelBuilderDefaultPersistency(SModelBuilderBase):
         model_xml_node = tree.getroot()
         model = self.extract_model_core_info(model_xml_node)
         model.path_to_model_file = path
-        self.extract_imports_and_registry(model_xml_node)
+        self.extract_registry(model_xml_node)
 
         for node_xml_node in model_xml_node.findall("node"):
             root_node = self.extract_node(model, node_xml_node, None)

--- a/mps-cli-py/src/mpscli/model/builder/SModelBuilderFilePerRootPersistency.py
+++ b/mps-cli-py/src/mpscli/model/builder/SModelBuilderFilePerRootPersistency.py
@@ -22,7 +22,7 @@ class SModelBuilderFilePerRootPersistency(SModelBuilderBase):
     def extract_root_node(self, model, mpsr_file):
         tree = ET.parse(mpsr_file)
         model_xml_node = tree.getroot()
-        self.extract_imports_and_registry(model_xml_node)
+        self.extract_registry(model_xml_node)
         root_node = model_xml_node.find("node")
         return self.extract_node(model, root_node, None)
 

--- a/mps-cli-py/tests/binary/test_binary_model_imports.py
+++ b/mps-cli-py/tests/binary/test_binary_model_imports.py
@@ -1,0 +1,25 @@
+import unittest
+
+from parameterized import parameterized
+
+from tests.test_base import TestBase
+
+
+class TestBinaryModelImports(TestBase):
+
+    @parameterized.expand(
+        [
+            (
+                "mps_cli_binary_persistency_generated",
+                "mps.cli.lanuse.library_top.binary_persistency.library_top",
+                "r:cf91f372-8bfd-44b8-8e34-024eb23e64a8",
+            ),
+        ]
+    )
+    def test_model_imports(self, test_data_location, model_name, imported_model_uuid):
+        self.doSetUp(test_data_location)
+
+        model = self.repo.find_model_by_name(model_name)
+        self.assertNotEqual(None, model)
+        self.assertIsInstance(model.imported_models, dict)
+        self.assertIn(imported_model_uuid, model.imported_models.values())

--- a/mps-cli-py/tests/test_model_imports.py
+++ b/mps-cli-py/tests/test_model_imports.py
@@ -1,0 +1,30 @@
+import unittest
+
+from parameterized import parameterized
+
+from tests.test_base import TestBase
+
+
+class TestModelImports(TestBase):
+
+    @parameterized.expand(
+        [
+            (
+                "mps_cli_lanuse_file_per_root",
+                "mps.cli.lanuse.library_top.library_top",
+                "r:ec5f093b-9d83-43a1-9b41-b5952da8b1ed",
+            ),
+            (
+                "mps_cli_lanuse_default_persistency",
+                "mps.cli.lanuse.library_top.default_persistency.library_top",
+                "r:ca00da79-915e-4bdb-9c30-11a341daf779",
+            ),
+        ]
+    )
+    def test_model_imports(self, test_data_location, model_name, imported_model_uuid):
+        self.doSetUp(test_data_location)
+
+        model = self.repo.find_model_by_name(model_name)
+        self.assertNotEqual(None, model)
+        self.assertIsInstance(model.imported_models, dict)
+        self.assertIn(imported_model_uuid, model.imported_models.values())


### PR DESCRIPTION
There is a need to analyze imported models when the model is read to be able to get the right model dependency graph. Added tests for model imports.